### PR TITLE
Use tar instead of unzip

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -132,7 +132,7 @@ android.applicationVariants.configureEach { variant ->
                 def output = new ByteArrayOutputStream()
 
                 exec {
-                    commandLine("unzip", "-t", pathToApk)
+                    commandLine("tar", "-tf", pathToApk)
                     standardOutput output
                 }
 


### PR DESCRIPTION
Use tar instead of unzip for windows and osx compatibility while still maintaining unix support.